### PR TITLE
Filtering HystrixCommands by pool name

### DIFF
--- a/runtime/src/main/resources/WEB-INF/hystrix-dashboard/components/hystrixCommand/hystrixCommand.js
+++ b/runtime/src/main/resources/WEB-INF/hystrix-dashboard/components/hystrixCommand/hystrixCommand.js
@@ -105,7 +105,7 @@
 		* When lots of commands are there, rendering all the commands make ui extremely slow.
 		*/
 		function shouldShowThisCommand(data) {
-		    if(allowedThreadPools.length === 0) {
+		    if(allowedCommandKeys.length === 0) {
 			return true;
 		    } else {
 			return allowedCommandKeys.includes(data["name"])

--- a/runtime/src/main/resources/WEB-INF/hystrix-dashboard/components/hystrixCommand/hystrixCommand.js
+++ b/runtime/src/main/resources/WEB-INF/hystrix-dashboard/components/hystrixCommand/hystrixCommand.js
@@ -76,7 +76,7 @@
 				if(!data.reportingHosts) {
 					data.reportingHosts = 1;
 				}
-							
+				
 				if(data && data.type == 'HystrixCommand') {
 					if (data.deleteData == 'true') {
 						deleteCircuit(data.name);

--- a/runtime/src/main/resources/WEB-INF/hystrix-dashboard/components/hystrixCommand/hystrixCommand.js
+++ b/runtime/src/main/resources/WEB-INF/hystrix-dashboard/components/hystrixCommand/hystrixCommand.js
@@ -76,8 +76,7 @@
 				if(!data.reportingHosts) {
 					data.reportingHosts = 1;
 				}
-				
-				
+							
 				if(data && data.type == 'HystrixCommand') {
 					if (data.deleteData == 'true') {
 						deleteCircuit(data.name);

--- a/runtime/src/main/resources/WEB-INF/hystrix-dashboard/components/hystrixCommand/hystrixCommand.js
+++ b/runtime/src/main/resources/WEB-INF/hystrix-dashboard/components/hystrixCommand/hystrixCommand.js
@@ -9,8 +9,8 @@
 		hystrixTemplateCircuitContainer = data;
 	});
 
-	const urlParam = new URLSearchParams(document.referrer);
-    	const allowedThreadPools = urlParam.get("threadPools") === null ? [] : urlParam.get("threadPools").split(",")
+	const urlParam = new URLSearchParams(window.location.search);
+    	const allowedCommandKeys = urlParam.get("commandKeys") === null ? [] : urlParam.get("commandKeys").split(",")
 	
 	function getRelativePath(path) {
 		var p = location.pathname.slice(0, location.pathname.lastIndexOf("/")+1);
@@ -109,7 +109,7 @@
 		    if(allowedThreadPools.length === 0) {
 			return true;
 		    } else {
-			return allowedThreadPools.includes(data["threadPool"])
+			return allowedCommandKeys.includes(data["name"])
 		    }
 		}
 		

--- a/runtime/src/main/resources/WEB-INF/hystrix-dashboard/components/hystrixThreadPool/hystrixThreadPool.js
+++ b/runtime/src/main/resources/WEB-INF/hystrix-dashboard/components/hystrixThreadPool/hystrixThreadPool.js
@@ -9,6 +9,9 @@
 		htmlTemplateContainer = data;
 	});
 
+	const urlParam = new URLSearchParams(window.location.search);
+	const allowedThreadPools = urlParam.get("threadPools") === null ? [] : urlParam.get("threadPools").split(",")
+	
 	function getRelativePath(path) {
 		var p = location.pathname.slice(0, location.pathname.lastIndexOf("/")+1);
 		return p + path;
@@ -61,6 +64,9 @@
 		/* public */ self.eventSourceMessageListener = function(e) {
 			var data = JSON.parse(e.data);
 			if(data) {
+				if(!shouldShowThisPool(data)) {
+        				return;
+				}
 				// check for reportingHosts (if not there, set it to 1 for singleHost vs cluster)
 				if(!data.reportingHosts) {
 					data.reportingHosts = 1;
@@ -74,6 +80,18 @@
 					}
 				}
 			}
+		}
+		
+		/**
+		* At times we are only interested in a subset of threadpools. 
+		* When lots of commands are there, rendering all the commands make ui extremely slow.
+		*/
+		function shouldShowThisPool(data) {
+		    if(allowedThreadPools.length === 0) {
+			return true;
+		    } else {
+			return allowedThreadPools.includes(data["name"])
+		    }
 		}
 		
 		/**


### PR DESCRIPTION
At times we are only interested in a subset of threadpool, rendering all the commands has repercussion that ui becomes extremely slow becaus it has to continuously update all the values and sort them as well. after this change we would be able to add interested threadpool as a query param, and only commands relevant to those pool will show up.